### PR TITLE
Docs: add categories for each aspect of the project

### DIFF
--- a/Docs/source/gateware/getting-started.rst
+++ b/Docs/source/gateware/getting-started.rst
@@ -1,0 +1,2 @@
+Getting Started
+===============

--- a/Docs/source/hardware/getting-started.rst
+++ b/Docs/source/hardware/getting-started.rst
@@ -1,0 +1,2 @@
+Getting Started
+===============

--- a/Docs/source/index.rst
+++ b/Docs/source/index.rst
@@ -1,9 +1,3 @@
-.. this is a comment, it is not rendered
-   when adding new *.rst files, reference them here
-   in this index.rst for them to be rendered and added to the
-   table of contents
-
-
 ======================
 Pico-Ice Documentation
 ======================
@@ -12,3 +6,24 @@ Pico-Ice Documentation
    :hidden:
 
    self
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Hardware / PCB
+   :hidden:
+
+   hardware/getting-started
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Software / SDK
+   :hidden:
+
+   software/getting-started
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Gateware / FPGA
+   :hidden:
+
+   gateware/getting-started

--- a/Docs/source/software/getting-started.rst
+++ b/Docs/source/software/getting-started.rst
@@ -1,0 +1,2 @@
+Getting Started
+===============


### PR DESCRIPTION
This is not much, but once the directory layout is settled, it gets easier to choose where to put things.

Here I propose the following (but feel free to suggest any change!):

- Hardware would offer an overview of the PCB, document the pinout, block
  diagrams, modifications...

- Software would offer an overview of the SDK, Get Started instructions,
  document its API.

- Gateware would document the FPGA: loading designs onto it, document the
  example wishbone interface, explain the toolchain for those new to
  FPGAs at all wanting to get started through the pico-ice board.

Also a comment removed.