### PR TITLE
Docs: fix a dead-link

### DIFF
--- a/Docs/source/software/getting-started.rst
+++ b/Docs/source/software/getting-started.rst
@@ -14,7 +14,7 @@ CMake setup
 
    It clones both the pico-sdk and pico-ice-sdk, replacing Raspberry Pi's ``pico_sdk_import.cmake``.
 
-.. _download: https://raw.githubusercontent.com/tinyvision-ai-inc/pico-ice-sdk/main/pico_ice_sdk_import.cmake
+.. _download: https://raw.githubusercontent.com/tinyvision-ai-inc/pico-ice-sdk/main/cmake/pico_ice_sdk_import.cmake
 
 ``CMakeLists.txt``
 


### PR DESCRIPTION
The documentation had a dead-link afer the SDK merge of `dev` branch.
I updated it.