### PR TITLE
Fix USB enumeration problem on macOS.

### DIFF
--- a/Firmware/pico-ice-default/main.c
+++ b/Firmware/pico-ice-default/main.c
@@ -125,6 +125,10 @@ int main(void) {
     // Prevent the LEDs from glowing slightly
     ice_led_init();
 
+    // Ensure that enumeration completes before main loop.
+    while (!tud_ready())
+        tud_task();
+
     while (true) {
         tud_task();
 


### PR DESCRIPTION
The pico-ice board does not appear as an USB device on macOS with default firmware versions 1.3 and 1.4.  The logs indicate that USB enumeration fails:

```
kernel: (AppleUSBXHCI) AppleUSBXHCIDevice: AppleUSBXHCIDevice::transferEvent: no endpoint 1 for event 0x0000010000003700 1b000000 01018001
kernel: (IOAccessoryManager) IOPortTransportState::setNominalSignalingFrequencies(): [Port-USB-C@1: USB2] Setting nominal signaling frequencies... (nominalSignalingFrequenciesHz: YES, nominalSignalingFrequenciesHz.count: 1)
kernel: (AppleUSBXHCI) AppleUSBXHCIRequest: AppleUSBXHCIRequest::finish: transfer completed with status 0xe00002ed
kernel: (IOUSBHostFamily) IOUSBHostDevice@00100000: IOUSBHostDevice::start_block_invoke: device descriptor fragment is invalid
kernel: (IOUSBHostFamily) IOUSBHostFamily::validateEndpointMaxPacketSize: USB 2.0 5.[5-8].3: endpoint 0x00 invalid wMaxPacketSize 0x0000
kernel: (IOUSBHostFamily) usb-drd0-port-hs@00100000: AppleUSBHostPort::enumerateDeviceComplete_block_invoke: enumeration failed
kernel: (IOUSBHostFamily) usb-drd0-port-hs@00100000: AppleUSBHostPort::terminateDevice: destroying 0x0000/0000/0000 (IOUSBHostDevice): enumeration failure
kernel: (IOUSBHostFamily) IOUSBHostDevice@00100000: IOUSBHostDevice::start_block_invoke: device will not be registered for matching
```

The tests were done on an M2 MacBook with macOS 14.1.  

---

This was introduced with commit 5f37b79.  The problem is that the delay in the main loop causes the RP2040 to send a lot of `NAK` responses and the Mac host gives up on the enumeration.  I reproduced the same situation with the [dev_hid_composite](https://github.com/raspberrypi/pico-examples/tree/master/usb/device/dev_hid_composite) example by adding a `sleep_ms(100)` in the main loop.  A solution is to ensure that USB enumeration has completed before going into the main loop:

```c
while (!tud_ready())
  tud_task();

while (true) {
  // main loop
}
```